### PR TITLE
Update navigation urls to be root relative

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,4 +2,4 @@
   url: 
 
 - title: About
-  url: about
+  url: /about


### PR DESCRIPTION
Navigation entries should have urls relative to the root of the project. 

I was running into issues, especially once I added other navigation items. EX: The links generated when navigating from "About" to "Contact" would be /hanuman/about/contact instead of /hanuman/contact/