### PR TITLE
Resolved sidebar relative-path conflict

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
                 {% assign current = null %}
             {% endif %}
       <li class="ampstart-nav-item ampstart-nav-dropdown relative " {{ current }}>
-          <li class="ampstart-faq-item"><a href="{{ site.baseurl }}{{ entry.url }}" class="text-decoration-none">{{ entry.title }}</a></li>
+          <li class="ampstart-faq-item"><a href="{{ site.url }}{{ entry.url }}" class="text-decoration-none">{{ entry.title }}</a></li>
       </li>
       {% endfor %}
     </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
                 {% assign current = null %}
             {% endif %}
       <li class="ampstart-nav-item ampstart-nav-dropdown relative " {{ current }}>
-          <li class="ampstart-faq-item"><a href="{{ site.url }}{{ entry.url }}" class="text-decoration-none">{{ entry.title }}</a></li>
+          <li class="ampstart-faq-item"><a href="{{ site.baseurl }}{{ site.url }}{{ entry.url }}" class="text-decoration-none">{{ entry.title }}</a></li>
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
**Issue**

I experienced an issue with the sidebar when going to my "about" page using "/" as my baseurl configuration. The sidebar "about" link was redirecting to "mypage.github.io/about/about". The "home" link was redirecting to "mypage.github.io/about/". This was a result of the sidebar linking to `{{site.baseurl}}` found in `_config.yml.`

**How this is experienced in your code**

As your comments in `_config.yml.` indicate...

> baseurl: "/hanuman/" # the subpath of your site, e.g. /blog/ or / for root

> url: "https://samanyougarg.com" # the base hostname & protocol for your site

This means at present... If `baseurl: "/"`, then `site.baseurl` will always be equal to "/". Since "/" points to a relative path, the sidebar of a user viewing the page mypage.github.io/about/ will always have a "Home" button which refers to "mypage.github.io/about/" and an"About" button which refers to "mypage.github.io/about/about". This can be tested in house.

**Resolution proposed**

Since site.url is intended to **always be** the base hostname & protocol for the site, so always an absolute path referring to the hostname as in your comments / installation instructions, it is reasonable to use both `site.url` and `site.baseurl` in conjunction as providing a reliable absolute-path for your hyperlinks in the navigation bar. This avoids unexpected behavior when not using a sub-path for a GitHub page. To illustrate... `baseurl: "/hanuman/"` and `url: "https://mmacheerpuppy.github.io"` will always meaningfully refer to `https://mmacheerpuppy.github.io/hanuman/{{entry.url}}`. 

Great theme by the way! Let me know how you feel about this.